### PR TITLE
Mark tools as strict for OpenAI parse compatibility

### DIFF
--- a/lib/tooling.py
+++ b/lib/tooling.py
@@ -98,7 +98,8 @@ class Tool:
                         param["name"] for param in self.parameters if param["required"]
                     ],
                     "additionalProperties": False
-                }
+                },
+                "strict": True,
             }
         }
 


### PR DESCRIPTION
## Summary
- Ensure tool schemas set `strict=True` so OpenAI can auto-parse tool calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad1a2d41cc832dbe81d887a5785200